### PR TITLE
Pin module version for sentry backtraffic api gateway

### DIFF
--- a/api_gateway_backtraffic.tf
+++ b/api_gateway_backtraffic.tf
@@ -1,5 +1,5 @@
 module "sentry_backtraffic_api_gateway" {
-  source = "terraform-aws-modules/apigateway-v2/aws"
+  source  = "terraform-aws-modules/apigateway-v2/aws"
   version = "4.0.0"
 
   name          = "${local.sentry_integration_prefix}-backtraffic"

--- a/api_gateway_backtraffic.tf
+++ b/api_gateway_backtraffic.tf
@@ -1,5 +1,6 @@
 module "sentry_backtraffic_api_gateway" {
   source = "terraform-aws-modules/apigateway-v2/aws"
+  version = "5.37.0"
 
   name          = "${local.sentry_integration_prefix}-backtraffic"
   description   = "HTTPS API Gateway for slack to tines traffic."

--- a/api_gateway_backtraffic.tf
+++ b/api_gateway_backtraffic.tf
@@ -1,6 +1,6 @@
 module "sentry_backtraffic_api_gateway" {
   source = "terraform-aws-modules/apigateway-v2/aws"
-  version = "5.37.0"
+  version = "4.0.0"
 
   name          = "${local.sentry_integration_prefix}-backtraffic"
   description   = "HTTPS API Gateway for slack to tines traffic."

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.38.0"
+      version = "~> 5.38.0"
     }
 
     snowflake = {

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.38.0"
+      version = "~> 5.38.0"
     }
 
     snowflake = {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.38.0"
+      version = ">= 5.38.0"
     }
 
     snowflake = {


### PR DESCRIPTION
this fixes an error with a backwards incompatible version that recently came out