### PR TITLE
Pin archive provider version due to bug in newer version.

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -13,7 +13,7 @@ terraform {
     }
 
     archive = {
-      source = "hashicorp/archive"
+      source  = "hashicorp/archive"
       version = "2.4.0"
     }
   }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -11,5 +11,10 @@ terraform {
       source  = "Snowflake-Labs/snowflake"
       version = "~> 0.64.0"
     }
+
+    archive = {
+      source = "hashicorp/archive"
+      version = "2.4.0"
+    }
   }
 }

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -13,7 +13,7 @@ terraform {
     }
 
     archive = {
-      source = "hashicorp/archive"
+      source  = "hashicorp/archive"
       version = "2.4.0"
     }
   }

--- a/examples/simple/versions.tf
+++ b/examples/simple/versions.tf
@@ -11,5 +11,10 @@ terraform {
       source  = "Snowflake-Labs/snowflake"
       version = "~> 0.64.0"
     }
+
+    archive = {
+      source = "hashicorp/archive"
+      version = "2.4.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -19,7 +19,7 @@ terraform {
     }
 
     archive = {
-      source = "hashicorp/archive"
+      source  = "hashicorp/archive"
       version = "2.4.0"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -17,5 +17,10 @@ terraform {
         snowflake.monitoring_role,
       ]
     }
+
+    archive = {
+      source = "hashicorp/archive"
+      version = "2.4.0"
+    }
   }
 }


### PR DESCRIPTION
Reference article:
https://support.hashicorp.com/hc/en-us/articles/27359812944019-Terraform-run-fails-with-archive-has-not-been-created-as-it-would-be-empty-when-using-the-archive-file-resource