### PR TITLE
Add support for sovereign cloud.

### DIFF
--- a/api_integration.tf
+++ b/api_integration.tf
@@ -5,7 +5,7 @@ resource "snowflake_api_integration" "sentry_integration_api_integration" {
   enabled              = true
   api_provider         = length(regexall(".*gov.*", local.aws_region)) > 0 ? "aws_gov_api_gateway" : "aws_api_gateway"
   api_allowed_prefixes = [local.inferred_api_gw_invoke_url]
-  api_aws_role_arn     = "arn:${var.arn_format}:iam::${local.account_id}:role/${local.api_gw_caller_role_name}"
+  api_aws_role_arn     = "arn:${local.aws_partition}:iam::${local.account_id}:role/${local.api_gw_caller_role_name}"
 }
 
 resource "snowflake_integration_grant" "sentry_integration_api_integration_grant" {

--- a/grants.tf
+++ b/grants.tf
@@ -1,4 +1,6 @@
 resource "snowflake_function_grant" "send_to_sentry_function_grant_usage" {
+  count = length(var.send_to_sentry_function_user_roles) == 0 ? 0 : 1
+
   provider = snowflake.monitoring_role
 
   database_name = var.database

--- a/variables.tf
+++ b/variables.tf
@@ -121,12 +121,14 @@ data "aws_partition" "current" {}
 
 
 locals {
-  account_id = data.aws_caller_identity.current.account_id
-  aws_region = data.aws_region.current.name
+  account_id     = data.aws_caller_identity.current.account_id
+  aws_region     = data.aws_region.current.name
+  aws_partition  = data.aws_partition.current.partition
+  aws_dns_suffix = data.aws_partition.current.dns_suffix
 }
 
 locals {
-  inferred_api_gw_invoke_url = "https://${aws_api_gateway_rest_api.ef_to_lambda.id}.execute-api.${local.aws_region}.amazonaws.com/"
+  inferred_api_gw_invoke_url = "https://${aws_api_gateway_rest_api.ef_to_lambda.id}.execute-api.${local.aws_region}.${local.aws_dns_suffix}/"
   sentry_integration_prefix  = "${var.prefix}-sentry-integration"
 }
 
@@ -140,8 +142,5 @@ locals {
   sentry_sns_policy_name = "${local.sentry_integration_prefix}-sns-policy"
   sentry_sns_topic_name  = "${local.sentry_integration_prefix}-sns-topic"
 
-  backtraffic_lambda_secrets_arns = [
-    var.jira_secrets_arn,
-    var.slack_secrets_arn,
-  ]
+  backtraffic_lambda_secrets_arns = [for i in [var.jira_secrets_arn, var.slack_secrets_arn]: i if i != null]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -142,5 +142,5 @@ locals {
   sentry_sns_policy_name = "${local.sentry_integration_prefix}-sns-policy"
   sentry_sns_topic_name  = "${local.sentry_integration_prefix}-sns-topic"
 
-  backtraffic_lambda_secrets_arns = [for i in [var.jira_secrets_arn, var.slack_secrets_arn]: i if i != null]
+  backtraffic_lambda_secrets_arns = [for i in [var.jira_secrets_arn, var.slack_secrets_arn] : i if i != null]
 }


### PR DESCRIPTION
Add support for sovereign cloud, changing ARN format to dynamic to match the specific sovereign cloud.  Also, make slack and jira as optional if their secret ARNs are not present.